### PR TITLE
Plot with shape

### DIFF
--- a/graph_rnaseq_counts.R
+++ b/graph_rnaseq_counts.R
@@ -8,11 +8,13 @@ library(ggplot2)
 library(reshape2)
 suppressPackageStartupMessages(library(dplyr))
 
-Args        <- commandArgs()
-dataFile    <- ifelse(is.na(Args[6]), "all.tsv",            Args[6])
-samplesFile <- ifelse(is.na(Args[7]), "deseq2/samples.txt", Args[7])
-outputFile  <- ifelse(is.na(Args[8]), "counts.pdf",         Args[8])
-plotStyle   <- ifelse(is.na(Args[9]), "default",            Args[9])
+Args           <- commandArgs()
+dataFile       <- ifelse(is.na(Args[6]), "all.tsv",            Args[6])
+samplesFile    <- ifelse(is.na(Args[7]), "deseq2/samples.txt", Args[7])
+outputFile     <- ifelse(is.na(Args[8]), "counts.pdf",         Args[8])
+plotStyle      <- ifelse(is.na(Args[9]), "default",            Args[9])
+shape          <- ifelse(is.na(Args[10]), "default",           Args[10])
+colourVariable <- ifelse(is.na(Args[11]), "stage",             Args[11])
 
 # Read data
 data <- read.delim(dataFile, header=TRUE, check.names=FALSE)
@@ -35,7 +37,19 @@ names(countData) <- gsub(" normalised.*$", "", names(countData))
 countData <- countData[, row.names(samples)]
 
 # Graph parameters
-colours <- as.numeric(samples$condition)
+shapePalette <- 21:25
+if (shape == 'default') { # don't use shape
+    colours <- as.numeric(samples$condition)
+    shapes <- rep(shapePalette[1], length(samples$condition))
+} else {
+    # check there aren't too many levels of condition for shape
+    if (nlevels(samples$condition) > length(shapePalette)) {
+        stop('The condition variable has more than levels than available shapes!')
+    } else {
+        shapes <- shapePalette[ as.numeric(samples$condition) ]
+        colours <- as.numeric(samples[[colourVariable]])
+    }
+}
 
 if (grepl("pdf$", outputFile)) {
     pdf(outputFile)
@@ -76,9 +90,13 @@ if (grepl("violin", plotStyle)) {
         if (!grepl("pdf$", outputFile)) {
             svg(paste0(outputFile, i, '.svg'))
         }
-        palette(rainbow(length(levels(samples$condition))))
+        if (shape == 'default') {
+            palette(rainbow(length(levels(samples$condition))))
+        } else {
+            palette(rainbow(length(levels(samples[[colourVariable]]))))
+        }
         par(mar=c(8.1, 4.1, 4.1, 2.1), xpd=TRUE)
-        plot(as.numeric(countData[i,]), axes=FALSE, ann=FALSE, pch=21,
+        plot(as.numeric(countData[i,]), axes=FALSE, ann=FALSE, pch=shapes,
              bg=colours)
         axis(1, at=1:ncol(countData), lab=names(countData), las=2, cex.axis=0.5)
         axis(2)
@@ -88,8 +106,15 @@ if (grepl("violin", plotStyle)) {
                            data[i,"Name"], data[i,"adjp"]))
         title(xlab="")
         title(ylab="Normalised Counts")
-        legend("topright", inset=c(0, -0.1), levels(samples$condition), pch=21,
-               pt.bg=1:length(levels(samples$condition)))
+
+        if (shape == 'default') {
+            legend("topright", inset=c(0, -0.1), levels(samples$condition), pch=21,
+                   pt.bg=1:length(levels(samples$condition)))            
+        } else {
+            legend("topright", inset=c(0, -0.1), levels(samples$condition), pch=shapePalette[ seq_len(nlevels(samples$condition)) ])
+            legend("right", inset=c(0, -0.1), levels(samples[[colourVariable]]), pch=21,
+                   pt.bg=1:length(levels(samples[[colourVariable]])))
+        }
         if (!grepl("pdf$", outputFile)) {
             graphics.off()
         }

--- a/graph_rnaseq_counts.R
+++ b/graph_rnaseq_counts.R
@@ -9,12 +9,12 @@ library(reshape2)
 suppressPackageStartupMessages(library(dplyr))
 
 Args           <- commandArgs()
-dataFile       <- ifelse(is.na(Args[6]), "all.tsv",            Args[6])
-samplesFile    <- ifelse(is.na(Args[7]), "deseq2/samples.txt", Args[7])
-outputFile     <- ifelse(is.na(Args[8]), "counts.pdf",         Args[8])
-plotStyle      <- ifelse(is.na(Args[9]), "default",            Args[9])
-shape          <- ifelse(is.na(Args[10]), "default",           Args[10])
-colourVariable <- ifelse(is.na(Args[11]), "stage",             Args[11])
+dataFile       <- ifelse(is.na(Args[6]),  "all.tsv",            Args[6])
+samplesFile    <- ifelse(is.na(Args[7]),  "deseq2/samples.txt", Args[7])
+outputFile     <- ifelse(is.na(Args[8]),  "counts.pdf",         Args[8])
+plotStyle      <- ifelse(is.na(Args[9]),  "default",            Args[9])
+shapeVariable  <- ifelse(is.na(Args[10]), "none",               Args[10])
+colourVariable <- ifelse(is.na(Args[11]), "stage",              Args[11])
 
 # Read data
 data <- read.delim(dataFile, header=TRUE, check.names=FALSE)
@@ -29,6 +29,17 @@ names(data)[names(data) == 'adjpval'] <- 'adjp'
 # Read samples
 samples <- read.table( samplesFile, header=TRUE, row.names=1 )
 
+# check shape and colour variables exist in the samples file
+if (shapeVariable != 'none') {
+    if (!any(grepl(shapeVariable, colnames(samples)))) {
+        stop(paste0('The shape variable, ', shapeVariable, ' does not exist as a column in the samples file!'))
+    }
+    # check colourVariable as well
+    if (!any(grepl(colourVariable, colnames(samples)))) {
+        stop(paste0('The colour variable, ', colourVariable, ' does not exist as a column in the samples file!'))
+    }
+}
+
 # Get counts
 countData <- data[,grepl(" normalised.*$", names(data))]
 names(countData) <- gsub(" normalised.*$", "", names(countData))
@@ -38,15 +49,15 @@ countData <- countData[, row.names(samples)]
 
 # Graph parameters
 shapePalette <- 21:25
-if (shape == 'default') { # don't use shape
+if (shapeVariable == 'none') { # don't use shape
     colours <- as.numeric(samples$condition)
     shapes <- rep(shapePalette[1], length(samples$condition))
 } else {
     # check there aren't too many levels of condition for shape
-    if (nlevels(samples$condition) > length(shapePalette)) {
-        stop('The condition variable has more than levels than available shapes!')
+    if (nlevels(samples[[shapeVariable]]) > length(shapePalette)) {
+        stop(paste0('The shape variable, ', shapeVariable, ' has more levels than available shapes (5)!'))
     } else {
-        shapes <- shapePalette[ as.numeric(samples$condition) ]
+        shapes <- shapePalette[ as.numeric(samples[[shapeVariable]]) ]
         colours <- as.numeric(samples[[colourVariable]])
     }
 }
@@ -90,7 +101,7 @@ if (grepl("violin", plotStyle)) {
         if (!grepl("pdf$", outputFile)) {
             svg(paste0(outputFile, i, '.svg'))
         }
-        if (shape == 'default') {
+        if (shapeVariable == 'none') {
             palette(rainbow(length(levels(samples$condition))))
         } else {
             palette(rainbow(length(levels(samples[[colourVariable]]))))
@@ -107,11 +118,11 @@ if (grepl("violin", plotStyle)) {
         title(xlab="")
         title(ylab="Normalised Counts")
 
-        if (shape == 'default') {
+        if (shapeVariable == 'none') {
             legend("topright", inset=c(0, -0.1), levels(samples$condition), pch=21,
                    pt.bg=1:length(levels(samples$condition)))            
         } else {
-            legend("topright", inset=c(0, -0.1), levels(samples$condition), pch=shapePalette[ seq_len(nlevels(samples$condition)) ])
+            legend("topright", inset=c(0, -0.1), levels(samples[[shapeVariable]]), pch=shapePalette[ seq_len(nlevels(samples[[shapeVariable]])) ])
             legend("right", inset=c(0, -0.1), levels(samples[[colourVariable]]), pch=21,
                    pt.bg=1:length(levels(samples[[colourVariable]])))
         }


### PR DESCRIPTION
Here are my changes to allow plotting RNAseq counts with shape as well as colour.

I've added two arguments shapeVariable and colourVariable.
The default for shapeVariable is 'none', which uses colour for the condition (and a circle for shape) as previously and ignores the colourVariable argument.
If shapeVariable is anything other than 'none', it tries to match it to one of the column names in the samples file. It won't accept a column with more than five levels.
colourVariable should then be the name of the column you want displayed with colour; the default is 'stage'.
The shape legend is plotted top-right and the colour legend in the middle on the right.